### PR TITLE
Fix failing tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,9 @@ go:
 
 sudo: required
 
+install:
+  - make deps
+
 before_install:
   - go get github.com/mhchia/sharding-p2p-poc
 

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,7 @@
+gx:
+	go get -u github.com/whyrusleeping/gx
+	go get -u github.com/whyrusleeping/gx-go
+
+deps: gx
+	gx --verbose install --global
+	gx-go rewrite

--- a/main_test.go
+++ b/main_test.go
@@ -5,12 +5,11 @@ import (
 	"testing"
 	"time"
 
-	golog "github.com/ipfs/go-log"
 	host "github.com/libp2p/go-libp2p-host"
 	peer "github.com/libp2p/go-libp2p-peer"
 	pstore "github.com/libp2p/go-libp2p-peerstore"
 	ma "github.com/multiformats/go-multiaddr"
-	gologging "github.com/whyrusleeping/go-logging"
+	// gologging "github.com/whyrusleeping/go-logging"
 )
 
 func makeUnbootstrappedNode(t *testing.T, ctx context.Context, number int) *Node {
@@ -186,9 +185,9 @@ func TestPeerListeningShards(t *testing.T) {
 	}
 }
 
-func connect(t *testing.T, a, b host.Host) {
+func connect(t *testing.T, ctx context.Context, a, b host.Host) {
 	pinfo := a.Peerstore().PeerInfo(a.ID())
-	err := b.Connect(context.Background(), pinfo)
+	err := b.Connect(ctx, pinfo)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -215,7 +214,7 @@ func makePeerNodes(t *testing.T, ctx context.Context) (*Node, *Node) {
 	if !node0.IsPeer(node1.ID()) || !node1.IsPeer(node0.ID()) {
 		t.Error("Failed to add peer")
 	}
-	connect(t, node0, node1)
+	connect(t, ctx, node0, node1)
 	return node0, node1
 }
 
@@ -225,7 +224,6 @@ func TestAddPeer(t *testing.T) {
 
 	makePeerNodes(t, ctx)
 }
-
 func TestBroadcastCollation(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -260,7 +258,7 @@ func makePartiallyConnected3Nodes(t *testing.T, ctx context.Context) []*Node {
 	if !node1.IsPeer(node2.ID()) || !node2.IsPeer(node1.ID()) {
 		t.Error()
 	}
-	connect(t, node1, node2)
+	connect(t, ctx, node1, node2)
 	return [](*Node){node0, node1, node2}
 }
 
@@ -283,7 +281,7 @@ func TestRouting(t *testing.T) {
 	// set the logger to DEBUG, to see the process of dht.FindPeer
 	// we should be able to see something like
 	// "dht: FindPeer <peer.ID d3wzD2> true routed.go:76", if successfully found the desire peer
-	golog.SetAllLoggers(gologging.DEBUG) // Change to DEBUG for extra info
+	// golog.SetAllLoggers(gologging.DEBUG) // Change to DEBUG for extra info
 	node0 := makeUnbootstrappedNode(t, ctx, 0)
 	node1 := makeUnbootstrappedNode(t, ctx, 1)
 	node2 := makeUnbootstrappedNode(t, ctx, 2)

--- a/package.json
+++ b/package.json
@@ -1,0 +1,94 @@
+{
+  "author": "mhchia",
+  "bugs": {
+    "url": "https://github.com/mhchia/sharding-p2p-poc"
+  },
+  "gx": {
+    "dvcsimport": "github.com/mhchia/sharding-p2p-poc"
+  },
+  "gxDependencies": [
+    {
+      "author": "whyrusleeping",
+      "hash": "QmY51bqSM5XgxQZqsBrQcRkKTnCb8EKpJpR9K6Qax7Njco",
+      "name": "go-libp2p",
+      "version": "6.0.6"
+    },
+    {
+      "hash": "QmTktQYCKzQjhxF6dk5xJPRuhHn3JBiKGvMLoiDy1mYmxC",
+      "name": "go-libp2p-kad-dht",
+      "version": "4.2.7"
+    },
+    {
+      "author": "whyrusleeping",
+      "hash": "QmXScvRbYh9X9okLuX9YMnz1HR4WgRTU2hocjBs15nmCNG",
+      "name": "go-libp2p-floodsub",
+      "version": "0.9.21"
+    },
+    {
+      "author": "jbenet",
+      "hash": "QmeiCcJfDW1GJnWUArudsv5rQsihpi4oyddPhdqo3CfX6i",
+      "name": "go-datastore",
+      "version": "2.4.1"
+    },
+    {
+      "hash": "QmcVVHfdyv15GVPk7NrxdWjh2hLVccXnoD8j2tyQShiXJb",
+      "name": "go-log",
+      "version": "1.5.3"
+    },
+    {
+      "author": "whyrusleeping",
+      "hash": "Qme1knMqwt1hKZbc1BmQFmnm9f36nyQGwXxPGVpVJ9rMK5",
+      "name": "go-libp2p-crypto",
+      "version": "1.6.2"
+    },
+    {
+      "author": "whyrusleeping",
+      "hash": "Qmb8T6YBBsjYsVGfrihQLfCJveczZnneSBqBKkYEBWDjge",
+      "name": "go-libp2p-host",
+      "version": "3.0.4"
+    },
+    {
+      "author": "whyrusleeping",
+      "hash": "QmPjvxTpVH8qJyQDnxnsxF9kv9jezKD1kozz1hs3fCGsNh",
+      "name": "go-libp2p-net",
+      "version": "3.0.5"
+    },
+    {
+      "author": "whyrusleeping",
+      "hash": "QmdVrMn1LhB4ybb8hMVaMLXnA8XRSewMnK6YqXKXoTcRvN",
+      "name": "go-libp2p-peer",
+      "version": "2.3.5"
+    },
+    {
+      "author": "whyrusleeping",
+      "hash": "QmZR2XWVVBCtbgBWnQhWk2xcQfaR3W8faQPriAiaaj7rsr",
+      "name": "go-libp2p-peerstore",
+      "version": "1.4.22"
+    },
+    {
+      "author": "whyrusleeping",
+      "hash": "QmZNkThpqfVXs9GNbexPrfBbXSLNYeKrE7jwFM2oqHbyqN",
+      "name": "go-libp2p-protocol",
+      "version": "1.0.0"
+    },
+    {
+      "author": "multiformats",
+      "hash": "QmYmsdtJ3HsodkePE3eU3TsCaP2YvPZJ4LoXnNkDE5Tpt7",
+      "name": "go-multiaddr",
+      "version": "1.3.0"
+    },
+    {
+      "author": "multiformats",
+      "hash": "QmRDePEiL4Yupq5EkcK3L3ko3iMgYaqUdLu7xc1kqs7dnV",
+      "name": "go-multicodec",
+      "version": "0.1.5"
+    }
+  ],
+  "gxVersion": "0.12.1",
+  "language": "go",
+  "license": "",
+  "name": "sharding-p2p-poc",
+  "releaseCmd": "git commit -a -m \"gx publish $VERSION\"",
+  "version": "0.0.0"
+}
+

--- a/shardmanager.go
+++ b/shardmanager.go
@@ -6,13 +6,14 @@ import (
 	"log"
 	"sync"
 
-	gethcrypto "github.com/ethereum/go-ethereum/crypto"
-	"github.com/golang/protobuf/proto"
 	floodsub "github.com/libp2p/go-floodsub"
 	peer "github.com/libp2p/go-libp2p-peer"
 	pstore "github.com/libp2p/go-libp2p-peerstore"
-	pbmsg "github.com/mhchia/sharding-p2p-poc/pb"
 	b58 "github.com/mr-tron/base58/base58"
+
+	gethcrypto "github.com/ethereum/go-ethereum/crypto"
+	"github.com/golang/protobuf/proto"
+	pbmsg "github.com/mhchia/sharding-p2p-poc/pb"
 )
 
 type ShardManager struct {
@@ -141,7 +142,7 @@ func (n *ShardManager) ListenShard(shardID ShardIDType) {
 	// listeningShards protocol
 	// TODO: maybe need refactoring
 	n.connectShardNodes(shardID)
-	// n.PublishListeningShards()
+	n.PublishListeningShards()
 
 	// shardCollations protocol
 	n.SubscribeShardCollations(shardID)


### PR DESCRIPTION
This PR should fix https://github.com/mhchia/sharding-p2p-poc/issues/2, and the tests listed below
- `TestRouting`
    - It seems the reason for it to fail is that dht queries fail. I ran the tests in `libp2p/go-libp2p-kad-dht` and found them failed as well. So further I tried `gx-go rw` to make the tests depend on versioned dependencies, and then the tests in `libp2p/go-libp2p-kad-dht` succeeded. Therefore, I tried it in our repo and it works, but for unknown reason.
        - Just a note that the dht failed because of `dht: error writing message, trying again:  proto: invalid UTF-8 string dht_net.go:271`. It seems the proto data contained invalid UTF-8 in the field `Key`.
    - Use gx to manage dependencies
- `TestPubSubNotifyListeningShards`
    - Uncomment `n.PublishListeningShards`