### PR TITLE
Add test for jumping shards

### DIFF
--- a/cli-example/setup-3-partial-connecting-nodes.sh
+++ b/cli-example/setup-3-partial-connecting-nodes.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+gx-go rw
+go build
+
+PORT=10000
+RPCPORT=13000
+SEED=0
+./sharding-p2p-poc -seed=$SEED -port=$((PORT+SEED)) -rpcport=$((RPCPORT+SEED)) &
+SEED=1
+./sharding-p2p-poc -seed=$SEED -port=$((PORT+SEED)) -rpcport=$((RPCPORT+SEED)) &
+SEED=2
+./sharding-p2p-poc -seed=$SEED -port=$((PORT+SEED)) -rpcport=$((RPCPORT+SEED)) &
+sleep 2
+./sharding-p2p-poc -rpcport=$((RPCPORT+1)) -client addpeer 127.0.0.1 $((PORT)) 0
+./sharding-p2p-poc -rpcport=$((RPCPORT+1)) -client addpeer 127.0.0.1 $((PORT+2)) 2
+
+gx-go uw

--- a/main_test.go
+++ b/main_test.go
@@ -421,3 +421,26 @@ func TestWithIPFSNodesRouting(t *testing.T) {
 		t.Error()
 	}
 }
+
+func TestListenShardConnectingPeers(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	nodes := makePartiallyConnected3Nodes(t, ctx)
+	// wait for mesh built
+	time.Sleep(time.Second * 2)
+	// 0 <-> 1 <-> 2
+	nodes[0].ListenShard(0)
+	time.Sleep(time.Millisecond * 100)
+	nodes[2].ListenShard(42)
+	time.Sleep(time.Millisecond * 100)
+	connWithNode2 := nodes[0].Network().ConnsToPeer(nodes[2].ID())
+	if len(connWithNode2) != 0 {
+		t.Error("Node 0 shouldn't have connection with node 2")
+	}
+	nodes[0].ListenShard(42)
+	time.Sleep(time.Second * 1)
+	connWithNode2 = nodes[0].Network().ConnsToPeer(nodes[2].ID())
+	if len(connWithNode2) == 0 {
+		t.Error("Node 0 should have connected to node 2 after listening to shard 42")
+	}
+}

--- a/node.go
+++ b/node.go
@@ -46,6 +46,7 @@ func (n *Node) GetFullAddr() string {
 	return fullAddr.String()
 }
 
+// TODO: should be changed to `Knows` and `HasConnections`
 func (n *Node) IsPeer(peerID peer.ID) bool {
 	for _, value := range n.Peerstore().Peers() {
 		if value == peerID {

--- a/shardmanager.go
+++ b/shardmanager.go
@@ -313,13 +313,12 @@ func (n *ShardManager) ListenShardCollations(shardID ShardIDType) {
 			// // )
 			// n.lock.Unlock()
 			log.Printf(
-				"%v: receive: collation: seqNo=%v, hash=%v, shardId=%v, number=%v, blobs=%v",
+				"%v: receive: collation: seqNo=%v, hash=%v, shardId=%v, number=%v",
 				n.node.Name(),
 				numCollationReceived,
 				collationHash[:8],
 				collation.GetShardID(),
 				collation.GetPeriod(),
-				collation.GetBlobs(),
 			)
 		}
 	}()

--- a/shardmanager.go
+++ b/shardmanager.go
@@ -129,8 +129,31 @@ func (n *ShardManager) connectShardNodes(shardID ShardIDType) error {
 		pi := n.node.Peerstore().PeerInfo(peerID)
 		pinfos = append(pinfos, pi)
 	}
-	// TODO: borrow the bootstrapConnect, should be modified/refactored and tested
-	return bootstrapConnect(context.Background(), n.node, pinfos)
+
+	// borrowed from `bootstrapConnect`, should be modified/refactored and tested
+	errs := make(chan error, len(pinfos))
+	var wg sync.WaitGroup
+	ctx := context.Background()
+	for _, p := range pinfos {
+		wg.Add(1)
+		go func(p pstore.PeerInfo) {
+			defer wg.Done()
+			if err := n.node.Connect(ctx, p); err != nil {
+				log.Printf(
+					"Failed to connect peer %v in shard %v: %s",
+					p.ID,
+					shardID,
+					err,
+				)
+				errs <- err
+				return
+			}
+			log.Printf("Successfully connected peer %v in shard %v", p.ID, shardID)
+		}(p)
+	}
+	wg.Wait()
+	// FIXME: ignore the errors when connecting shard peers for now
+	return nil
 }
 
 func (n *ShardManager) ListenShard(shardID ShardIDType) {
@@ -139,8 +162,7 @@ func (n *ShardManager) ListenShard(shardID ShardIDType) {
 	}
 	n.AddPeerListeningShard(n.node.ID(), shardID)
 
-	// listeningShards protocol
-	// TODO: maybe need refactoring
+	// TODO: should set a critiria: if we have enough peers in the shard, don't connect shard nodes
 	n.connectShardNodes(shardID)
 	n.PublishListeningShards()
 
@@ -150,16 +172,17 @@ func (n *ShardManager) ListenShard(shardID ShardIDType) {
 }
 
 func (n *ShardManager) UnlistenShard(shardID ShardIDType) {
-	if n.IsShardListened(shardID) {
-		n.RemovePeerListeningShard(n.node.ID(), shardID)
-
-		// listeningShards protocol
-		// TODO: some changes to existing peers?
-		n.PublishListeningShards()
-
-		// shardCollations protocol
-		n.UnsubscribeShardCollations(shardID)
+	if !n.IsShardListened(shardID) {
+		return
 	}
+	n.RemovePeerListeningShard(n.node.ID(), shardID)
+
+	// listeningShards protocol
+	// TODO: should we remove some peers in this shard?
+	n.PublishListeningShards()
+
+	// shardCollations protocol
+	n.UnsubscribeShardCollations(shardID)
 }
 
 func (n *ShardManager) GetListeningShards() []ShardIDType {


### PR DESCRIPTION
Besides,
- Don't print blobs in collation to avoid unnecessary output.
- Fix `port` and `rpcport`, no matter what `seed` is used.
    -  `port` and `rpcport` can be changed by specifying them when starting a node. To call RPC to the node, `rpcport` should be specified.
    - Accordingly, `addpeer ip seed` is changed to `addpeer ip port seed`. The example usage can be found in `cli-example/setup-3-partial-connecting-nodes.sh`
